### PR TITLE
update graph table charset to utf8

### DIFF
--- a/db_schema/graph-db-schema.sql
+++ b/db_schema/graph-db-schema.sql
@@ -11,7 +11,7 @@ CREATE TABLE `graph`.`endpoint` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_endpoint` (`endpoint`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT  DEFAULT CHARSET =utf8 COLLATE =utf8_unicode_ci;
 
 DROP TABLE if exists `graph`.`endpoint_counter`;
 CREATE TABLE `graph`.`endpoint_counter` (
@@ -25,7 +25,7 @@ CREATE TABLE `graph`.`endpoint_counter` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_endpoint_id_counter` (`endpoint_id`, `counter`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET =utf8 COLLATE =utf8_unicode_ci;
 
 DROP TABLE if exists `graph`.`tag_endpoint`;
 CREATE TABLE `graph`.`tag_endpoint` (
@@ -37,5 +37,5 @@ CREATE TABLE `graph`.`tag_endpoint` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_tag_endpoint_id` (`tag`, `endpoint_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB  DEFAULT CHARSET =utf8 COLLATE =utf8_unicode_ci;
 


### PR DESCRIPTION
graph 库中的表格 当tag里有中文时，会发生查询异常，修改成utf8, 测试支持中文。
