### PR TITLE
修正监控项无法显示中文问题，可支持中文 Tag

### DIFF
--- a/db_schema/dashboard-db-schema.sql
+++ b/db_schema/dashboard-db-schema.sql
@@ -19,9 +19,11 @@
 -- Table structure for table `dashboard_graph`
 --
 
-CREATE database `dashboard`;
-
-use `dashboard`;
+CREATE DATABASE dashboard
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
+USE dashboard;
+SET NAMES utf8;
 
 DROP TABLE IF EXISTS `dashboard_graph`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/db_schema/graph-db-schema.sql
+++ b/db_schema/graph-db-schema.sql
@@ -1,6 +1,8 @@
-create database graph;
-use graph;
-set names utf8;
+CREATE DATABASE graph
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
+USE graph;
+SET NAMES utf8;
 
 DROP TABLE if exists `graph`.`endpoint`;
 CREATE TABLE `graph`.`endpoint` (
@@ -11,7 +13,7 @@ CREATE TABLE `graph`.`endpoint` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_endpoint` (`endpoint`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE if exists `graph`.`endpoint_counter`;
 CREATE TABLE `graph`.`endpoint_counter` (
@@ -25,7 +27,7 @@ CREATE TABLE `graph`.`endpoint_counter` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_endpoint_id_counter` (`endpoint_id`, `counter`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE if exists `graph`.`tag_endpoint`;
 CREATE TABLE `graph`.`tag_endpoint` (
@@ -37,5 +39,5 @@ CREATE TABLE `graph`.`tag_endpoint` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_tag_endpoint_id` (`tag`, `endpoint_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/db_schema/links-db-schema.sql
+++ b/db_schema/links-db-schema.sql
@@ -1,6 +1,8 @@
-CREATE DATABASE falcon_links;
+CREATE DATABASE falcon_links
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
 USE falcon_links;
-SET NAMES 'utf8';
+SET NAMES utf8;
 
 
 DROP TABLE IF EXISTS alert;

--- a/db_schema/portal-db-schema.sql
+++ b/db_schema/portal-db-schema.sql
@@ -1,4 +1,4 @@
-CREATE DATABASE falcon_portal;
+CREATE DATABASE falcon_portal
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
 USE falcon_portal;

--- a/db_schema/portal-db-schema.sql
+++ b/db_schema/portal-db-schema.sql
@@ -1,6 +1,8 @@
 CREATE DATABASE falcon_portal;
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
 USE falcon_portal;
-SET NAMES 'utf8';
+SET NAMES utf8;
 
 /**
  * 这里的机器是从机器管理系统中同步过来的
@@ -204,7 +206,7 @@ CREATE TABLE `cluster` (
   `last_update` TIMESTAMP      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `creator`     VARCHAR(255)   NOT NULL,
   PRIMARY KEY (`id`)
-) 
+)
   ENGINE =InnoDB
   DEFAULT CHARSET=utf8
   COLLATE=utf8_unicode_ci;

--- a/db_schema/uic-db-schema.sql
+++ b/db_schema/uic-db-schema.sql
@@ -1,8 +1,10 @@
-create database uic;
-use uic;
-set names utf8;
+create database uic
+  DEFAULT CHARACTER SET utf8
+  DEFAULT COLLATE utf8_general_ci;
+USE uic;
+SET NAMES utf8;
 
-drop table if exists team;
+DROP TABLE if exists team;
 CREATE TABLE `team` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
@@ -16,7 +18,7 @@ CREATE TABLE `team` (
 /**
  * role: -1:blocked 0:normal 1:admin 2:root
  */
-drop table if exists `user`;
+DROP TABLE if exists `user`;
 CREATE TABLE `user` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(64) NOT NULL,
@@ -33,7 +35,7 @@ CREATE TABLE `user` (
   UNIQUE KEY `idx_user_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-drop table if exists `rel_team_user`;
+DROP TABLE if exists `rel_team_user`;
 CREATE TABLE `rel_team_user` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `tid` int(10) unsigned not null,
@@ -43,7 +45,7 @@ CREATE TABLE `rel_team_user` (
   KEY `idx_rel_uid` (`uid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-drop table if exists `session`;
+DROP TABLE if exists `session`;
 CREATE TABLE `session` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `uid` int(10) unsigned not null,


### PR DESCRIPTION
make databases support Chinese (i.g., change the encoding to UTF-8)

When creating databases, set the corresponding variables to utf8.
Specify the default character sets of tables to `utf8` so that the
tables are able to support Chinese.
