### PR TITLE
移除每个 table 自己指定 CHARSET 和 COLLATE 参数的部分

### DIFF
--- a/db_schema/dashboard-db-schema.sql
+++ b/db_schema/dashboard-db-schema.sql
@@ -18,7 +18,7 @@ CREATE TABLE `dashboard_graph` (
   `falcon_tags` varchar(512) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `idx_sid` (`screen_id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4626 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=4626;
 
 DROP TABLE IF EXISTS `dashboard_screen`;
 CREATE TABLE `dashboard_screen` (
@@ -28,7 +28,7 @@ CREATE TABLE `dashboard_screen` (
   `time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `idx_pid` (`pid`)
-) ENGINE=InnoDB AUTO_INCREMENT=952 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=952;
 
 DROP TABLE IF EXISTS `tmp_graph`;
 CREATE TABLE `tmp_graph` (
@@ -39,4 +39,4 @@ CREATE TABLE `tmp_graph` (
   `time_` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_ck` (`ck`)
-) ENGINE=InnoDB AUTO_INCREMENT=365189 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=365189;

--- a/db_schema/dashboard-db-schema.sql
+++ b/db_schema/dashboard-db-schema.sql
@@ -1,24 +1,3 @@
--- MySQL dump 10.13  Distrib 5.5.31, for Linux (x86_64)
---
--- Host: 127.0.0.1    Database: dashboard
--- ------------------------------------------------------
--- Server version	5.5.31-log
-
-/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
-/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
-/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
-/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
-/*!40103 SET TIME_ZONE='+00:00' */;
-/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
-/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
-/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
-/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
-
---
--- Table structure for table `dashboard_graph`
---
-
 CREATE DATABASE dashboard
   DEFAULT CHARACTER SET utf8
   DEFAULT COLLATE utf8_general_ci;
@@ -26,8 +5,6 @@ USE dashboard;
 SET NAMES utf8;
 
 DROP TABLE IF EXISTS `dashboard_graph`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dashboard_graph` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `title` char(128) NOT NULL,
@@ -42,15 +19,8 @@ CREATE TABLE `dashboard_graph` (
   PRIMARY KEY (`id`),
   KEY `idx_sid` (`screen_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=4626 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `dashboard_screen`
---
 
 DROP TABLE IF EXISTS `dashboard_screen`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dashboard_screen` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `pid` int(11) unsigned NOT NULL DEFAULT '0',
@@ -59,15 +29,8 @@ CREATE TABLE `dashboard_screen` (
   PRIMARY KEY (`id`),
   KEY `idx_pid` (`pid`)
 ) ENGINE=InnoDB AUTO_INCREMENT=952 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-
---
--- Table structure for table `tmp_graph`
---
 
 DROP TABLE IF EXISTS `tmp_graph`;
-/*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `tmp_graph` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `endpoints` varchar(10240) NOT NULL DEFAULT '',
@@ -77,14 +40,3 @@ CREATE TABLE `tmp_graph` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_ck` (`ck`)
 ) ENGINE=InnoDB AUTO_INCREMENT=365189 DEFAULT CHARSET=utf8;
-/*!40101 SET character_set_client = @saved_cs_client */;
-/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
-
-/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
-/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
-/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
-/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
-/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
-/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
-/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-

--- a/db_schema/graph-db-schema.sql
+++ b/db_schema/graph-db-schema.sql
@@ -40,4 +40,3 @@ CREATE TABLE `graph`.`tag_endpoint` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_tag_endpoint_id` (`tag`, `endpoint_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-

--- a/db_schema/graph-db-schema.sql
+++ b/db_schema/graph-db-schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE `graph`.`endpoint` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_endpoint` (`endpoint`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;
 
 DROP TABLE if exists `graph`.`endpoint_counter`;
 CREATE TABLE `graph`.`endpoint_counter` (
@@ -27,7 +27,7 @@ CREATE TABLE `graph`.`endpoint_counter` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_endpoint_id_counter` (`endpoint_id`, `counter`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;
 
 DROP TABLE if exists `graph`.`tag_endpoint`;
 CREATE TABLE `graph`.`tag_endpoint` (
@@ -39,4 +39,4 @@ CREATE TABLE `graph`.`tag_endpoint` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_tag_endpoint_id` (`tag`, `endpoint_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;

--- a/db_schema/links-db-schema.sql
+++ b/db_schema/links-db-schema.sql
@@ -17,5 +17,5 @@ CREATE TABLE alert
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 

--- a/db_schema/links-db-schema.sql
+++ b/db_schema/links-db-schema.sql
@@ -4,7 +4,6 @@ CREATE DATABASE falcon_links
 USE falcon_links;
 SET NAMES utf8;
 
-
 DROP TABLE IF EXISTS alert;
 CREATE TABLE alert
 (
@@ -18,4 +17,3 @@ CREATE TABLE alert
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
-

--- a/db_schema/links-db-schema.sql
+++ b/db_schema/links-db-schema.sql
@@ -13,7 +13,4 @@ CREATE TABLE alert
   create_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   UNIQUE KEY alert_path(path)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;

--- a/db_schema/portal-db-schema.sql
+++ b/db_schema/portal-db-schema.sql
@@ -24,7 +24,7 @@ CREATE TABLE host
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 /**
@@ -43,7 +43,7 @@ CREATE TABLE `grp` (
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 DROP TABLE IF EXISTS grp_host;
@@ -56,7 +56,7 @@ CREATE TABLE grp_host
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 /**
@@ -78,7 +78,7 @@ CREATE TABLE tpl
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 DROP TABLE IF EXISTS strategy;
@@ -100,7 +100,7 @@ CREATE TABLE `strategy` (
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 DROP TABLE IF EXISTS expression;
@@ -120,7 +120,7 @@ CREATE TABLE `expression` (
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 DROP TABLE IF EXISTS grp_tpl;
@@ -133,7 +133,7 @@ CREATE TABLE `grp_tpl` (
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 CREATE TABLE `plugin_dir` (
   `id`          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -146,7 +146,7 @@ CREATE TABLE `plugin_dir` (
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 
 DROP TABLE IF EXISTS action;
@@ -163,7 +163,7 @@ CREATE TABLE `action` (
 )
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
-  COLLATE =utf8_unicode_ci;
+  COLLATE =utf8_general_ci;
 
 /**
  * nodata mock config
@@ -185,9 +185,9 @@ CREATE TABLE `mockcfg` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_name` (`name`)
 )
-  ENGINE=InnoDB
-  DEFAULT CHARSET=utf8
-  COLLATE=utf8_unicode_ci;
+  ENGINE =InnoDB
+  DEFAULT CHARSET =utf8
+  COLLATE =utf8_general_ci;
 
 /**
  *  aggregator cluster metric config table
@@ -208,5 +208,5 @@ CREATE TABLE `cluster` (
   PRIMARY KEY (`id`)
 )
   ENGINE =InnoDB
-  DEFAULT CHARSET=utf8
-  COLLATE=utf8_unicode_ci;
+  DEFAULT CHARSET =utf8
+  COLLATE =utf8_general_ci;

--- a/db_schema/portal-db-schema.sql
+++ b/db_schema/portal-db-schema.sql
@@ -21,10 +21,7 @@ CREATE TABLE host
   update_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   UNIQUE KEY idx_host_hostname (hostname)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 /**
  * 机器分组信息
@@ -39,10 +36,7 @@ CREATE TABLE `grp` (
   come_from   TINYINT(4)       NOT NULL DEFAULT '0',
   PRIMARY KEY (id),
   UNIQUE KEY idx_host_grp_grp_name (grp_name)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 DROP TABLE IF EXISTS grp_host;
 CREATE TABLE grp_host
@@ -51,10 +45,7 @@ CREATE TABLE grp_host
   host_id INT UNSIGNED NOT NULL,
   KEY idx_grp_host_grp_id (grp_id),
   KEY idx_grp_host_host_id (host_id)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 /**
  * 监控策略模板
@@ -72,10 +63,7 @@ CREATE TABLE tpl
   PRIMARY KEY (id),
   UNIQUE KEY idx_tpl_name (tpl_name),
   KEY idx_tpl_create_user (create_user)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 DROP TABLE IF EXISTS strategy;
 CREATE TABLE `strategy` (
@@ -93,10 +81,7 @@ CREATE TABLE `strategy` (
   `tpl_id`      INT(10) UNSIGNED NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `idx_strategy_tpl_id` (`tpl_id`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 DROP TABLE IF EXISTS expression;
 CREATE TABLE `expression` (
@@ -112,10 +97,7 @@ CREATE TABLE `expression` (
   `create_user` VARCHAR(64)      NOT NULL DEFAULT '',
   `pause`       TINYINT(1)       NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 DROP TABLE IF EXISTS grp_tpl;
 CREATE TABLE `grp_tpl` (
@@ -124,10 +106,7 @@ CREATE TABLE `grp_tpl` (
   `bind_user` VARCHAR(64)      NOT NULL DEFAULT '',
   KEY `idx_grp_tpl_grp_id` (`grp_id`),
   KEY `idx_grp_tpl_tpl_id` (`tpl_id`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 CREATE TABLE `plugin_dir` (
   `id`          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -137,10 +116,7 @@ CREATE TABLE `plugin_dir` (
   `create_at`   TIMESTAMP        NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   KEY `idx_plugin_dir_grp_id` (`grp_id`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 DROP TABLE IF EXISTS action;
 CREATE TABLE `action` (
@@ -153,10 +129,7 @@ CREATE TABLE `action` (
   `after_callback_sms`   TINYINT(4)       NOT NULL DEFAULT '0',
   `after_callback_mail`  TINYINT(4)       NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 /**
  * nodata mock config
@@ -177,10 +150,7 @@ CREATE TABLE `mockcfg` (
   `t_modify` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'last modify time',
   PRIMARY KEY (`id`),
   UNIQUE KEY `uniq_name` (`name`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;
 
 /**
  *  aggregator cluster metric config table
@@ -199,7 +169,4 @@ CREATE TABLE `cluster` (
   `last_update` TIMESTAMP      NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `creator`     VARCHAR(255)   NOT NULL,
   PRIMARY KEY (`id`)
-)
-  ENGINE =InnoDB
-  DEFAULT CHARSET =utf8
-  COLLATE =utf8_general_ci;
+) ENGINE =InnoDB;

--- a/db_schema/portal-db-schema.sql
+++ b/db_schema/portal-db-schema.sql
@@ -26,7 +26,6 @@ CREATE TABLE host
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
 
-
 /**
  * 机器分组信息
  * come_from 0: 从机器管理同步过来的；1: 从页面创建的
@@ -45,7 +44,6 @@ CREATE TABLE `grp` (
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
 
-
 DROP TABLE IF EXISTS grp_host;
 CREATE TABLE grp_host
 (
@@ -57,7 +55,6 @@ CREATE TABLE grp_host
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
-
 
 /**
  * 监控策略模板
@@ -80,7 +77,6 @@ CREATE TABLE tpl
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
 
-
 DROP TABLE IF EXISTS strategy;
 CREATE TABLE `strategy` (
   `id`          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -102,7 +98,6 @@ CREATE TABLE `strategy` (
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
 
-
 DROP TABLE IF EXISTS expression;
 CREATE TABLE `expression` (
   `id`          INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -121,7 +116,6 @@ CREATE TABLE `expression` (
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
-
 
 DROP TABLE IF EXISTS grp_tpl;
 CREATE TABLE `grp_tpl` (
@@ -147,7 +141,6 @@ CREATE TABLE `plugin_dir` (
   ENGINE =InnoDB
   DEFAULT CHARSET =utf8
   COLLATE =utf8_general_ci;
-
 
 DROP TABLE IF EXISTS action;
 CREATE TABLE `action` (

--- a/db_schema/uic-db-schema.sql
+++ b/db_schema/uic-db-schema.sql
@@ -13,7 +13,7 @@ CREATE TABLE `team` (
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_team_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;
 
 /**
  * role: -1:blocked 0:normal 1:admin 2:root
@@ -33,7 +33,7 @@ CREATE TABLE `user` (
   `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_user_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;
 
 DROP TABLE if exists `rel_team_user`;
 CREATE TABLE `rel_team_user` (
@@ -43,7 +43,7 @@ CREATE TABLE `rel_team_user` (
   PRIMARY KEY (`id`),
   KEY `idx_rel_tid` (`tid`),
   KEY `idx_rel_uid` (`uid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;
 
 DROP TABLE if exists `session`;
 CREATE TABLE `session` (
@@ -54,7 +54,7 @@ CREATE TABLE `session` (
   PRIMARY KEY (`id`),
   KEY `idx_session_uid` (`uid`),
   KEY `idx_session_sig` (`sig`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB;
 
 /*900150983cd24fb0d6963f7d28e17f72*/
 /*insert into `user`(`name`, `passwd`, `role`, `created`) values('root', md5('abc'), 2, now());*/

--- a/db_schema/uic-db-schema.sql
+++ b/db_schema/uic-db-schema.sql
@@ -58,4 +58,3 @@ CREATE TABLE `session` (
 
 /*900150983cd24fb0d6963f7d28e17f72*/
 /*insert into `user`(`name`, `passwd`, `role`, `created`) values('root', md5('abc'), 2, now());*/
-


### PR DESCRIPTION
每个 Database 已经指定了 `CHARACTER` 和 `COLLATE` 了，如果 tables 在各自自己指定成不同的参数，在 `JOIN` 查询的时候就会出错。虽然目前 open-falcon 没有因為 `JOIN` 的查询而造成出错，但还是觉得把未来可能会造成错误的地方拿掉比较好。
